### PR TITLE
Enable prefixing for bud.js assets

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -18,8 +18,8 @@ export default async bud => {
          * These paths are expressed relative to the `@src` directory
          */
         .entry({
-            "frontend": [`/frontend/js/app.js`, `/frontend/scss/app.scss`], // [`./sources/app.js`, `./sources/app.css`]
-            "admin": [`/admin/js/app.js`, `/admin/scss/app.scss`]
+            "demo-plugin-frontend": [`/frontend/js/app.js`, `/frontend/scss/app.scss`], // [`./sources/app.js`, `./sources/app.css`]
+            "demo-plugin-admin": [`/admin/js/app.js`, `/admin/scss/app.scss`]
         })
 
         .provide({

--- a/src/Demo_Plugin.php
+++ b/src/Demo_Plugin.php
@@ -105,7 +105,7 @@ class Demo_Plugin
     {
 
         add_action('admin_enqueue_scripts', function () {
-            $this->enqueue_bud_entrypoint('admin');
+            $this->enqueue_bud_entrypoint('demo-plugin-admin');
         }, 100);
 
 		// Add Setup Command
@@ -124,7 +124,7 @@ class Demo_Plugin
     {
 
         add_action('wp_enqueue_scripts', function () {
-            $this->enqueue_bud_entrypoint('frontend');
+            $this->enqueue_bud_entrypoint('demo-plugin-frontend');
         }, 100);
 
     }


### PR DESCRIPTION
Avoid conflicts of assets by prefixing entries with plugin name