### PR TITLE
Exclude only root lib folder

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -41,4 +41,4 @@ tests/
 # Build artifacts and cache
 .budfiles/
 phpcs-report.xml
-lib/
+/lib/


### PR DESCRIPTION
During bundling the `lib` folder was ignored recursively, breaking some vendor packages. The change ensure the only the plugins lib folder will be excluded.