### PR TITLE
Exclude resources/ from distribution and update ACF JSON path

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -42,3 +42,6 @@ tests/
 .budfiles/
 phpcs-report.xml
 /lib/
+
+# Source assets (compiled to build/)
+resources/

--- a/docs/acf-json-sync.md
+++ b/docs/acf-json-sync.md
@@ -2,11 +2,11 @@
 
 There is no ultimate way how to do it but throughout the year the following pattern has proven to be effective and flexible.
 
-All ACF field group JSON files should be stored in `resources/acf-json/`.
+All ACF field group JSON files should be stored in `acf-json/` at the plugin root level.
 
 To enable ACF JSON sync in your plugin:
 
-1. Create the `resources/acf-json` directory
+1. Create the `acf-json` directory at the plugin root
 2. Add the following code to your `load_dependencies()` method in the main Demo_Plugin class:
 
 The code examples are based on ACF´s documentation for [local JSON](https://www.advancedcustomfields.com/resources/local-json/).
@@ -28,7 +28,7 @@ private function load_dependencies(): void {
         'acf/settings/save_json',
         function () {
             if ( wp_get_environment_type() !== 'production' ) {
-                return DEMO_PLUGIN_PATH . 'resources/acf-json';
+                return DEMO_PLUGIN_PATH . 'acf-json';
             }
             return '';
         }
@@ -36,7 +36,7 @@ private function load_dependencies(): void {
     add_filter(
         'acf/settings/load_json',
         function ( $paths ) {
-            $paths[] = DEMO_PLUGIN_PATH . 'resources/acf-json';
+            $paths[] = DEMO_PLUGIN_PATH . 'acf-json';
             return $paths;
         }
     );
@@ -82,7 +82,7 @@ class Config {
      */
     public function save_path(): string {
         if ( wp_get_environment_type() !== 'production' ) {
-            return DEMO_PLUGIN_PATH . 'resources/acf-json';
+            return DEMO_PLUGIN_PATH . 'acf-json';
         }
         return '';
     }
@@ -97,7 +97,7 @@ class Config {
         // Optional: Remove default path
         // unset( $paths[0] );
         
-        $paths[] = DEMO_PLUGIN_PATH . 'resources/acf-json';
+        $paths[] = DEMO_PLUGIN_PATH . 'acf-json';
         return $paths;
     }
 }

--- a/docs/bundeling.md
+++ b/docs/bundeling.md
@@ -18,7 +18,7 @@ The project uses `@wordpress/scripts` (wp-scripts) for bundling and compiling fr
 ## Directory Structure
 
 ```
-resources/
+resources/            # Source assets (excluded from distribution)
 ├── admin/            # Admin-specific assets
 │   ├── js/
 │   │   └── app.js    # Admin JS entry point
@@ -31,7 +31,11 @@ resources/
 │   ├── scss/
 │   │   └── app.scss  # Frontend styles entry point
 │   └── images/       # Images referenced in frontend SCSS
-└── acf-json/         # ACF field group JSON files
+build/                # Compiled assets (distributed)
+├── demo-plugin-admin.js
+├── demo-plugin-admin.css
+├── demo-plugin-frontend.js
+└── demo-plugin-frontend.css
 ```
 
 ## Entrypoints


### PR DESCRIPTION
## Summary

- Add resources/ to .distignore to prevent source assets from being bundled
- Move acf-json location from resources/acf-json/ to plugin root (acf-json/)
- Update bundeling.md documentation with new directory structure
- Update acf-json-sync.md with correct path references

## Why

The resources/ folder contains source JS/SCSS files that are compiled into build/. Previously, these source files were being included in distribution packages even though only the compiled assets are needed. This change:

1. Excludes resources/ from distribution packages
2. Moves acf-json/ to plugin root level (separate from source assets)
3. Updates documentation to reflect the new structure