### PR TITLE
Label bash code blocks and document expressive code usage

### DIFF
--- a/docs/bundeling.mdx
+++ b/docs/bundeling.mdx
@@ -99,8 +99,8 @@ Webpack resolves the path, copies the image to `build/`, and updates the URL in 
 
 For files that need to be copied as-is without being referenced in SCSS or JS (e.g., fonts loaded via `@font-face` with external URLs, pre-compiled libraries), you can optionally add the CopyPlugin:
 
-```bash
-npm install copy-webpack-plugin --save-dev```
+```bash title="Terminal"
+npm install copy-webpack-plugin --save-dev
 ```
 
 Then, modify `webpack.config.js`:

--- a/docs/documentation.mdx
+++ b/docs/documentation.mdx
@@ -39,6 +39,21 @@ Short intro paragraph.
 ...
 ```
 
+## Code Blocks
+
+Use Expressive Code attributes on fenced code blocks. These attributes are ignored when unsupported, so it is best practice to include them consistently.
+
+- Always specify a language for syntax highlighting (e.g. `bash`, `php`, `js`).
+- Add a `title="..."` when the snippet belongs to a file or a terminal session.
+
+```bash title="Terminal"
+npm run build
+```
+
+```php title="src/Demo_Plugin.php"
+private function enqueue_entrypoint( string $entry, array $localize_data = array() ): void
+```
+
 ## Folder Structures
 
 When documenting folder layouts, use the Starlight FileTree component so directories and files render consistently.

--- a/docs/sentry.mdx
+++ b/docs/sentry.mdx
@@ -7,7 +7,7 @@ description: Error monitoring integration using the Sentry SDK.
 Using [Sentry](https://sentry.io/) in your WordPress plugin allows you to monitor and track errors effectively. Below are the steps to integrate Sentry into your plugin.
 
 ## 1. Install sentry SDK
-```
+```bash title="Terminal"
 composer require sentry/sentry
 ```
 

--- a/docs/wp-env.mdx
+++ b/docs/wp-env.mdx
@@ -35,7 +35,7 @@ Scripts that interact with wp-env are defined in `package.json`:
 
 The `env:cli` script is pre-configured with the correct working directory:
 
-```bash
+```bash title="Terminal"
 npm run env:cli -- composer run i18n:compile
 npm run env:cli -- composer run phpstan
 ```
@@ -64,7 +64,7 @@ npm run env:cli -- composer run phpstan
 
 Then run it with:
 
-```bash
+```bash title="Terminal"
 npm run env:cli -- composer run my-script
 ```
 


### PR DESCRIPTION
## Summary
- add Expressive Code guidance for labeling code blocks in docs
- tag terminal command blocks with bash and titles across docs
- fix the CopyPlugin install snippet formatting

## Testing
- Not run (not requested)