### PR TITLE
feat: add jQuery global aliases via webpack.ProvidePlugin

### DIFF
--- a/docs/bundeling.mdx
+++ b/docs/bundeling.mdx
@@ -179,6 +179,40 @@ The method automatically:
 - Enqueues both JS and CSS if they exist
 - Applies `wp_localize_script()` when data is provided
 
+## jQuery Support
+
+jQuery is configured with global aliases (`$` and `jQuery`) via webpack.ProvidePlugin in `webpack.config.js`:
+
+```js title="webpack.config.js"
+plugins: [
+    ...defaultConfig.plugins,
+    new webpack.ProvidePlugin({
+        $: 'jquery',
+        jQuery: 'jquery',
+    }),
+],
+```
+
+This allows you to use jQuery in your JavaScript without importing it:
+
+```javascript title="app.js"
+// Both work out of the box
+jQuery(document).ready(function() {
+    console.log('jQuery ready');
+});
+
+// Or using the $ alias
+$(document).ready(function() {
+    console.log('$ ready');
+});
+```
+
+jQuery is externalized by wp-scripts and loaded from WordPress core. The `.asset.php` file automatically includes `jquery` as a dependency when detected in your code.
+
+:::note
+The ProvidePlugin has minimal build-time overhead. If your project doesn't use jQuery, you can safely remove the plugin configuration from `webpack.config.js`.
+:::
+
 ## Gutenberg Blocks
 
 Block assets are handled automatically. See [Create Blocks](create-blocks.mdx) for details on block development and asset management.

--- a/resources/admin/js/app.js
+++ b/resources/admin/js/app.js
@@ -1,4 +1,7 @@
 /**
- * All of the code for your public-facing JavaScript source
+ * All of the code for your admin-facing JavaScript source
  * should reside in this file.
+ *
+ * jQuery is available via global aliases ($ and jQuery).
+ * Example: $(document).ready(function() { ... });
  */

--- a/resources/frontend/js/app.js
+++ b/resources/frontend/js/app.js
@@ -1,4 +1,7 @@
 /**
- * All of the code for your admin-facing JavaScript source
+ * All of the code for your public-facing JavaScript source
  * should reside in this file.
+ *
+ * jQuery is available via global aliases ($ and jQuery).
+ * Example: $(document).ready(function() { ... });
  */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,16 @@
 const path = require( 'path' );
+const webpack = require( 'webpack' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 module.exports = {
 	...defaultConfig,
+	plugins: [
+		...defaultConfig.plugins,
+		new webpack.ProvidePlugin( {
+			$: 'jquery',
+			jQuery: 'jquery',
+		} ),
+	],
 	entry: {
 		'demo-plugin-frontend': [
 			path.resolve( __dirname, 'resources/frontend/js/app.js' ),


### PR DESCRIPTION
## Summary

- Add webpack.ProvidePlugin to webpack.config.js for global `$` and `jQuery` aliases
- Update bundeling documentation with jQuery support section and examples
- Add jQuery usage comments to admin and frontend entry point files

## Changes

- `webpack.config.js`: Add webpack.ProvidePlugin configuration
- `docs/bundeling.mdx`: Add jQuery Support section with code examples and overhead note
- `resources/admin/js/app.js`: Add jQuery documentation comment
- `resources/frontend/js/app.js`: Add jQuery documentation comment

## Notes

The ProvidePlugin adds minimal build-time overhead. Projects not using jQuery can safely remove this configuration from webpack.config.js.