### PR TITLE
fix: push release version updates to source branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve source branch
+        id: resolve-branch
+        run: |
+          BRANCH=$(git branch -r --contains "${{ github.sha }}" \
+            | grep -v 'HEAD' \
+            | sed 's|[[:space:]]*origin/||' \
+            | head -1 \
+            | xargs)
+          if [ -z "$BRANCH" ]; then
+            echo "::error::Could not resolve source branch for tag ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: PHP dependencies cache
         uses: actions/cache@v4
@@ -50,7 +66,16 @@ jobs:
         run: wp package install wp-cli/dist-archive-command:@stable
 
       - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: |
+          RELEASE_VERSION="${GITHUB_REF#refs/*/}"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          if [[ "$RELEASE_VERSION" =~ -(alpha|beta|rc) ]]; then
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+            echo "MAKE_LATEST=false" >> $GITHUB_ENV
+          else
+            echo "IS_PRERELEASE=false" >> $GITHUB_ENV
+            echo "MAKE_LATEST=true" >> $GITHUB_ENV
+          fi
 
       - name: Update Version in WordPress files
         run: |
@@ -74,15 +99,13 @@ jobs:
         if: always()
         run: npm run env:stop
 
-      - name: Update resources
-        uses: test-room-7/action-update-file@v1
-        with:
-          file-path: |
-            src/Demo_Plugin.php
-            demo-plugin.php
-            README.txt
-          commit-msg: Update Version in WordPress specific files
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and push version updates
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/Demo_Plugin.php demo-plugin.php README.txt
+          git commit -m "Update Version in WordPress specific files"
+          git push origin "$(git rev-parse HEAD):refs/heads/${{ steps.resolve-branch.outputs.branch }}"
 
       - name: Release
         uses: ncipollo/release-action@v1
@@ -90,3 +113,5 @@ jobs:
           allowUpdates: true
           omitBodyDuringUpdate: true
           artifacts: "./demo-plugin-${{ env.RELEASE_VERSION }}.zip"
+          prerelease: ${{ env.IS_PRERELEASE }}
+          makeLatest: ${{ env.MAKE_LATEST }}


### PR DESCRIPTION
## Summary
- add `fetch-depth: 0` and resolve the source branch from the tagged commit before any version updates
- commit version-file updates with git and push explicitly to the resolved source branch instead of defaulting to `main`
- classify prerelease tags (`alpha`, `beta`, `rc`) and pass `prerelease`/`makeLatest` flags to the release action