### PR TITLE
fix(ci): include composer.json in PHP cache key hash

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Generate cache keys
         id: cache-keys
         run: |
-          echo "php-key=php-${{ inputs.mode }}-${{ runner.os }}-${{ hashFiles('composer.lock') }}" >> $GITHUB_OUTPUT
+          echo "php-key=php-${{ inputs.mode }}-${{ runner.os }}-${{ hashFiles('composer.lock', 'composer.json') }}" >> $GITHUB_OUTPUT
           echo "node-key=node-${{ inputs.mode }}-${{ runner.os }}-${{ hashFiles('package-lock.json') }}" >> $GITHUB_OUTPUT
 
       - name: PHP Dependencies cache


### PR DESCRIPTION
## Problem

The PHP dependency cache key was based solely on `composer.lock`. This means changes to `composer.json` that don't touch `composer.lock` — such as adding a new autoloader entry (`psr-4`, `classmap`, `files`, etc.) — would not invalidate the cache. The old stale `vendor/` directory would be restored and the new autoloader configuration would never be applied.

## Fix

Include `composer.json` in the `hashFiles()` call for the PHP cache key:

```
hashFiles('composer.lock', 'composer.json')
```

Any change to autoloader config, platform requirements, or other `composer.json` settings now produces a new cache key, forcing a fresh `composer install`.

## Why not Node?

`npm ci` enforces that `package.json` and `package-lock.json` are in sync and errors if they diverge — so hashing `package-lock.json` alone is sufficient on the Node side.