### PR TITLE
Fix Strauss download failure handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
       "composer exec -- wp setup"
     ],
     "prefix-namespaces": [
-      "sh -c 'if [ ! -f ./bin/strauss.phar ] || [ $(find ./bin/strauss.phar -mtime +1 -print 2>/dev/null) ]; then rm -f ./bin/strauss.phar && curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/latest/download/strauss.phar; fi'",
+      "sh -c 'if [ ! -f ./bin/strauss.phar ] || [ $(find ./bin/strauss.phar -mtime +1 -print 2>/dev/null) ]; then rm -f ./bin/strauss.phar && curl -f -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/latest/download/strauss.phar; fi'",
       "@php bin/strauss.phar",
       "@composer dump-autoload"
     ],

--- a/src/Cli/Setup.php
+++ b/src/Cli/Setup.php
@@ -295,7 +295,10 @@ class Setup {
 			return '';
 		}
 
-		$words = array_filter( $words, 'strlen' );
+		$words = array_filter(
+			$words,
+			static fn ( string $word ): bool => '' !== $word
+		);
 
 		return implode( '_', array_map( 'ucfirst', $words ) );
 	}


### PR DESCRIPTION
## Summary
- preserve the existing Strauss PHAR age check
- make the Strauss download fail cleanly on HTTP errors by passing curl -f

## Validation
- Verified the Strauss latest download URL resolves with HTTP 200