### PR TITLE
Bootstrap Composer before wp-env activation

### DIFF
--- a/.agents/skills/wp-plugin-bp/SKILL.md
+++ b/.agents/skills/wp-plugin-bp/SKILL.md
@@ -61,6 +61,9 @@ Detailed docs are available as `references/doc-*.mdx`. In the source repo these 
 
 If the host has no working environment (ddev,wp-studio etc) use wp-env.
 - Start env: `npm run env:start`
+- First-start bootstrap: `npm run env:start` runs `npm run env:bootstrap`, which installs Composer dependencies in the `cli` container before activating the plugin.
+- Recovery start without lifecycle scripts: `npm run env:start:no-scripts`
+- Composer inside wp-env: `npm run env:composer:install` or `npm run env:composer:update`
 - Run commands: `npm run env:cli composer run phpstan` or `npm run env:cli i18n:extract`
 
 All PHP and wp-cli commands/tools can run inside wp-env. npm commands need to run on the host.

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -7,6 +7,6 @@
 		"wp-content/plugins/": "./tests/setup/plugins/"
 	},
 	"lifecycleScripts": {
-		"afterStart": "wp-env run cli wp plugin activate demo-plugin"
+		"afterStart": "npm run env:bootstrap"
 	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ This plugin is a modern WordPress plugin with strict conventions and automated w
 - **Blocks**: Run `npm run create-block`. Use the `wp-plugin-bp` skill for block guidance.
 - **Abilities API**: Implement interfaces in `src/Abilities/`, register via Loader. Use the `wp-plugin-bp` skill for ability guidance.
 - **i18n**: Extract with `composer run i18n:extract`, compile with `composer run i18n:compile`. Use the `wp-plugin-bp` skill for translation work.
-- **wp-env**: Start with `npm run env:start`. Use the `wp-plugin-bp` skill when tests are involved.
+- **wp-env**: Start with `npm run env:start`. The lifecycle runs `npm run env:bootstrap`, which installs Composer dependencies inside wp-env before activating the plugin. Use `npm run env:start:no-scripts` for recovery/debugging and `npm run env:composer:install` or `npm run env:composer:update` for Composer work inside wp-env. Use the `wp-plugin-bp` skill when tests are involved.
 - **Testing**: Run application tests with `npm run test:php`. Use the `wp-plugin-bp` skill for testing guidance.
 - **Plugin upgrades**: Use the `wp-plugin-bp` skill or ask naturally to sync with upstream project conventions.
 - **Official WordPress skills**: `.agents/skills/wp-*/` contains focused skills for block development, Interactivity API, PHPStan, project triage, and REST API work. Use the `wp-plugin-bp` skill `wp-skills` workflow to refresh or add official WordPress skills.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ After replacement, setup asks whether to install agent skills for ongoing AI-ass
 | Command | Purpose |
 | --- | --- |
 | `npm run env:start` | Start the local WordPress environment |
+| `npm run env:start:no-scripts` | Start wp-env without lifecycle scripts for recovery/debugging |
+| `npm run env:bootstrap` | Install Composer dependencies in wp-env and activate the plugin |
+| `npm run env:composer:install` | Install Composer dependencies inside wp-env |
+| `npm run env:composer:update` | Update Composer dependencies inside wp-env |
 | `npm run env:stop` | Stop the environment |
 | `npm run build` | Build production assets |
 | `npm run start` | Watch and rebuild assets during development |

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -98,7 +98,7 @@ Use WP-CLI's `plugin install` command inside the `tests-cli` container. Extend t
 ```json title=".wp-env.json"
 {
 	"lifecycleScripts": {
-		"afterStart": "<existing_commands> && wp-env run tests-cli wp plugin install advanced-custom-fields --activate"
+		"afterStart": "npm run env:bootstrap && wp-env run tests-cli wp plugin install advanced-custom-fields --activate"
 	}
 }
 ```

--- a/docs/wp-env.mdx
+++ b/docs/wp-env.mdx
@@ -31,9 +31,14 @@ Scripts that interact with wp-env are defined in `package.json`:
 | Script | Description |
 |--------|-------------|
 | `npm run env:start` | Start the Docker containers |
+| `npm run env:start:no-scripts` | Start the containers without lifecycle scripts |
 | `npm run env:stop` | Stop the Docker containers |
 | `npm run env:destroy` | Remove containers and data |
 | `npm run env:cli` | Run commands inside the container |
+| `npm run env:composer:install` | Install Composer dependencies inside the `cli` container |
+| `npm run env:composer:update` | Update Composer dependencies inside the `cli` container |
+| `npm run env:plugin:activate` | Activate Demo Plugin inside the `cli` container |
+| `npm run env:bootstrap` | Install Composer dependencies, then activate Demo Plugin |
 | `npm run test:php` | Run PHPUnit application tests in the test container |
 
 ### Running Commands Inside wp-env
@@ -45,7 +50,22 @@ npm run env:cli -- composer run i18n:compile
 npm run env:cli -- composer run phpstan
 ```
 
-On every `env:start`, the `afterStart` hook activates Demo Plugin in the `cli` container.
+On every `env:start`, the `afterStart` hook runs `npm run env:bootstrap`. This installs Composer dependencies inside the `cli` container before activating Demo Plugin, so a fresh checkout can start wp-env even when `vendor/autoload.php` does not exist yet.
+
+Run Composer maintenance commands inside wp-env with the dedicated scripts:
+
+```bash title="Terminal"
+npm run env:composer:install
+npm run env:composer:update
+```
+
+If a lifecycle command fails while you are debugging dependencies, start the containers without lifecycle scripts, run the Composer command, then run the bootstrap manually:
+
+```bash title="Terminal"
+npm run env:start:no-scripts
+npm run env:composer:update
+npm run env:bootstrap
+```
 
 ## Adding Custom Scripts
 
@@ -83,6 +103,7 @@ The plugin uses wp-env in the deploy workflow to compile translations. This requ
 
 - Docker must be installed and running
 - The first start downloads WordPress core and may take a few minutes
+- The first start also runs `composer install` inside the `cli` container before plugin activation
 - Data persists between starts unless you run `env:destroy`
-- The `afterStart` lifecycle script automatically activates the plugin
+- The `afterStart` lifecycle script automatically installs Composer dependencies and activates the plugin
 - The PHP version is pinned to 8.1 because `composer run i18n:compile` uses `wp i18n make-php`

--- a/package.json
+++ b/package.json
@@ -15,9 +15,14 @@
     "packages-update": "wp-scripts packages-update",
     "create-block": "bash -lc \"mkdir -p src/Blocks && cd src/Blocks && npx @wordpress/create-block --no-plugin --namespace=demo-plugin --textdomain=demo-plugin\"",
     "env:start": "wp-env start --update",
+    "env:start:no-scripts": "wp-env start --update --no-scripts",
     "env:stop": "wp-env stop",
     "env:destroy": "wp-env destroy",
     "env:cli": "wp-env run cli --env-cwd=wp-content/plugins/demo-plugin",
+    "env:composer:install": "wp-env run cli --env-cwd=wp-content/plugins/demo-plugin composer install --prefer-dist --no-interaction --no-progress",
+    "env:composer:update": "wp-env run cli --env-cwd=wp-content/plugins/demo-plugin composer update --prefer-dist --no-interaction --no-progress",
+    "env:plugin:activate": "wp-env run cli wp plugin activate demo-plugin",
+    "env:bootstrap": "npm run env:composer:install && npm run env:plugin:activate",
     "test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/demo-plugin bash -lc 'composer install --working-dir=tests --no-interaction && vendor/bin/phpunit'"
   }
 }


### PR DESCRIPTION
Summary: Adds reusable wp-env Composer install/update/bootstrap scripts, runs the bootstrap lifecycle before plugin activation, and documents recovery with env:start:no-scripts. Verification: jq empty package.json; jq empty .wp-env.json; npm run env:start -- --auto-port; npm run env:cli -- wp plugin status demo-plugin; npm run env:composer:install; npm run env:bootstrap.