### PR TITLE
Use wp-env for deploy packaging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,18 +62,10 @@ jobs:
           sed -i -E 's/([[:blank:]]*\*[[:blank:]]*Version:[[:blank:]]*).*/\1${{ env.RELEASE_VERSION }}/' demo-plugin.php
           sed -i -E 's/Stable tag: .*/Stable tag: ${{ env.RELEASE_VERSION }}/' README.txt
 
-      - name: Configure deploy wp-env
-        run: |
-          cat > .wp-env.override.json <<'JSON'
-          {
-            "phpVersion": "8.4"
-          }
-          JSON
-
       - name: Start wp-env
         run: npm run env:start
 
-      - name: Install latest WP-CLI in wp-env
+      - name: Download latest WP-CLI in wp-env
         run: |
           npm run env:cli -- bash -lc 'curl -fL -o /tmp/wp-cli-nightly.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar'
           npm run env:cli -- php /tmp/wp-cli-nightly.phar cli version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,17 @@ jobs:
           key: ${{ needs.setup.outputs.node-cache-key }}
           fail-on-cache-miss: true
 
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: wp-cli
+
+      # Keep v3.1.0 on the host because this version uses the external zip binary,
+      # which is not available in wp-env. When WP-CLI 3.0.0 is available in wp-env,
+      # move bundling inline there with dist-archive-command:@stable, which uses PHP ZipArchive.
+      - name: Install dist-archive-command on host
+        run: wp package install wp-cli/dist-archive-command:v3.1.0
+
       - name: Set env
         run: |
           RELEASE_VERSION="${GITHUB_REF#refs/*/}"
@@ -65,20 +76,12 @@ jobs:
       - name: Start wp-env
         run: npm run env:start
 
-      - name: Download latest WP-CLI in wp-env
-        run: |
-          npm run env:cli -- bash -lc 'curl -fL -o /tmp/wp-cli-nightly.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar'
-          npm run env:cli -- php /tmp/wp-cli-nightly.phar cli version
-
-      - name: Install dist-archive-command in wp-env
-        run: npm run env:cli -- php -d memory_limit=-1 /tmp/wp-cli-nightly.phar package install wp-cli/dist-archive-command:@stable
-
       - name: Compile translations in wp-env from po files
         run: npm run env:cli composer run i18n:compile
 
-      - name: Build dist-archive in wp-env
+      - name: Build dist-archive on host
         run: |
-          npm run env:cli -- php -d memory_limit=-1 /tmp/wp-cli-nightly.phar dist-archive . ./demo-plugin-${{ env.RELEASE_VERSION }}.zip --plugin-dirname=demo-plugin
+          wp dist-archive . ./demo-plugin-${{ env.RELEASE_VERSION }}.zip --plugin-dirname=demo-plugin
           mkdir tmp-build
           unzip demo-plugin-${{ env.RELEASE_VERSION }}.zip -d tmp-build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,18 +62,31 @@ jobs:
           sed -i -E 's/([[:blank:]]*\*[[:blank:]]*Version:[[:blank:]]*).*/\1${{ env.RELEASE_VERSION }}/' demo-plugin.php
           sed -i -E 's/Stable tag: .*/Stable tag: ${{ env.RELEASE_VERSION }}/' README.txt
 
+      - name: Configure deploy wp-env
+        run: |
+          cat > .wp-env.override.json <<'JSON'
+          {
+            "phpVersion": "8.4"
+          }
+          JSON
+
       - name: Start wp-env
         run: npm run env:start
 
+      - name: Install latest WP-CLI in wp-env
+        run: |
+          npm run env:cli -- bash -lc 'curl -fL -o /tmp/wp-cli-nightly.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar'
+          npm run env:cli -- php /tmp/wp-cli-nightly.phar cli version
+
       - name: Install dist-archive-command in wp-env
-        run: npm run env:cli wp package install wp-cli/dist-archive-command:v3.1.0
+        run: npm run env:cli -- php -d memory_limit=-1 /tmp/wp-cli-nightly.phar package install wp-cli/dist-archive-command:@stable
 
       - name: Compile translations in wp-env from po files
         run: npm run env:cli composer run i18n:compile
 
       - name: Build dist-archive in wp-env
         run: |
-          npm run env:cli wp dist-archive . ./demo-plugin-${{ env.RELEASE_VERSION }}.zip --plugin-dirname=demo-plugin
+          npm run env:cli -- php -d memory_limit=-1 /tmp/wp-cli-nightly.phar dist-archive . ./demo-plugin-${{ env.RELEASE_VERSION }}.zip --plugin-dirname=demo-plugin
           mkdir tmp-build
           unzip demo-plugin-${{ env.RELEASE_VERSION }}.zip -d tmp-build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,14 +44,6 @@ jobs:
           key: ${{ needs.setup.outputs.node-cache-key }}
           fail-on-cache-miss: true
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          tools: wp-cli
-
-      - name: Install latest version of dist-archive-command
-        run: wp package install wp-cli/dist-archive-command:v3.1.0
-
       - name: Set env
         run: |
           RELEASE_VERSION="${GITHUB_REF#refs/*/}"
@@ -73,12 +65,15 @@ jobs:
       - name: Start wp-env
         run: npm run env:start
 
+      - name: Install dist-archive-command in wp-env
+        run: npm run env:cli wp package install wp-cli/dist-archive-command:v3.1.0
+
       - name: Compile translations in wp-env from po files
         run: npm run env:cli composer run i18n:compile
 
-      - name: Build dist-archive on host
+      - name: Build dist-archive in wp-env
         run: |
-          wp dist-archive . ./demo-plugin-${{ env.RELEASE_VERSION }}.zip --plugin-dirname=demo-plugin
+          npm run env:cli wp dist-archive . ./demo-plugin-${{ env.RELEASE_VERSION }}.zip --plugin-dirname=demo-plugin
           mkdir tmp-build
           unzip demo-plugin-${{ env.RELEASE_VERSION }}.zip -d tmp-build
 

--- a/docs/github-actions.mdx
+++ b/docs/github-actions.mdx
@@ -58,7 +58,7 @@ Triggered when any tag is pushed.
    - `demo-plugin.php` (plugin header `Version:`)
    - `README.txt` (`Stable tag:`)
 
-2. **Build** — writes a deploy-only `.wp-env.override.json` to run wp-env with PHP 8.4, starts wp-env, downloads the latest WP-CLI nightly phar inside the `cli` container, installs `wp-cli/dist-archive-command:@stable`, compiles translations inside the container, then generates the distributable `.zip` with `wp dist-archive` from the same containerized environment. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
+2. **Build** — starts wp-env, downloads the latest WP-CLI nightly phar inside the `cli` container, installs `wp-cli/dist-archive-command:@stable`, compiles translations inside the container, then generates the distributable `.zip` with `wp dist-archive` from the same containerized environment. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
 
 3. **Persist stable release versions** — for stable tags only, the workflow commits the three changed files and pushes them back to the repository default branch. Stable releases are assumed to be created from that default branch.
 

--- a/docs/github-actions.mdx
+++ b/docs/github-actions.mdx
@@ -58,7 +58,7 @@ Triggered when any tag is pushed.
    - `demo-plugin.php` (plugin header `Version:`)
    - `README.txt` (`Stable tag:`)
 
-2. **Build** — starts wp-env, compiles translations inside the container, then generates the distributable `.zip` with `wp dist-archive`. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
+2. **Build** — starts wp-env, installs `wp-cli/dist-archive-command` inside the `cli` container, compiles translations inside the container, then generates the distributable `.zip` with `wp dist-archive` from the same containerized environment. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
 
 3. **Persist stable release versions** — for stable tags only, the workflow commits the three changed files and pushes them back to the repository default branch. Stable releases are assumed to be created from that default branch.
 

--- a/docs/github-actions.mdx
+++ b/docs/github-actions.mdx
@@ -58,7 +58,7 @@ Triggered when any tag is pushed.
    - `demo-plugin.php` (plugin header `Version:`)
    - `README.txt` (`Stable tag:`)
 
-2. **Build** — starts wp-env, downloads the latest WP-CLI nightly phar inside the `cli` container, installs `wp-cli/dist-archive-command:@stable`, compiles translations inside the container, then generates the distributable `.zip` with `wp dist-archive` from the same containerized environment. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
+2. **Build** — starts wp-env, compiles translations inside the container, then generates the distributable `.zip` on the host with `wp dist-archive`. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
 
 3. **Persist stable release versions** — for stable tags only, the workflow commits the three changed files and pushes them back to the repository default branch. Stable releases are assumed to be created from that default branch.
 

--- a/docs/github-actions.mdx
+++ b/docs/github-actions.mdx
@@ -58,7 +58,7 @@ Triggered when any tag is pushed.
    - `demo-plugin.php` (plugin header `Version:`)
    - `README.txt` (`Stable tag:`)
 
-2. **Build** — starts wp-env, installs `wp-cli/dist-archive-command` inside the `cli` container, compiles translations inside the container, then generates the distributable `.zip` with `wp dist-archive` from the same containerized environment. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
+2. **Build** — writes a deploy-only `.wp-env.override.json` to run wp-env with PHP 8.4, starts wp-env, downloads the latest WP-CLI nightly phar inside the `cli` container, installs `wp-cli/dist-archive-command:@stable`, compiles translations inside the container, then generates the distributable `.zip` with `wp dist-archive` from the same containerized environment. Files listed in `.distignore` (e.g. source maps, dev dependencies, test files) are automatically excluded from the archive — no manual cleanup needed.
 
 3. **Persist stable release versions** — for stable tags only, the workflow commits the three changed files and pushes them back to the repository default branch. Stable releases are assumed to be created from that default branch.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "wp-scripts format ./resources",
     "packages-update": "wp-scripts packages-update",
     "create-block": "bash -lc \"mkdir -p src/Blocks && cd src/Blocks && npx @wordpress/create-block --no-plugin --namespace=demo-plugin --textdomain=demo-plugin\"",
-    "env:start": "wp-env start --update --autoPort",
+    "env:start": "wp-env start --update",
     "env:stop": "wp-env stop",
     "env:destroy": "wp-env destroy",
     "env:cli": "wp-env run cli --env-cwd=wp-content/plugins/demo-plugin",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "wp-scripts format ./resources",
     "packages-update": "wp-scripts packages-update",
     "create-block": "bash -lc \"mkdir -p src/Blocks && cd src/Blocks && npx @wordpress/create-block --no-plugin --namespace=demo-plugin --textdomain=demo-plugin\"",
-    "env:start": "wp-env start --update",
+    "env:start": "wp-env start --update --autoPort",
     "env:stop": "wp-env stop",
     "env:destroy": "wp-env destroy",
     "env:cli": "wp-env run cli --env-cwd=wp-content/plugins/demo-plugin",


### PR DESCRIPTION
## Summary
- keep deploy packaging on the host with setup-php and WP-CLI
- keep wp-cli/dist-archive-command pinned to v3.1.0
- document why wp-env inline packaging is deferred until WP-CLI 3.0.0 and dist-archive-command:@stable can be used
- clarify that translations compile in wp-env while the distributable archive is built on the host

## Reasoning
- dist-archive-command v3.1.0 uses the external zip binary and works with the host flow
- newer dist-archive-command versions require newer WP-CLI and are not easily installable in wp-env today
- the future flow should move bundling inline to wp-env once WP-CLI 3.0.0 is available there and the latest dist-archive-command can use PHP ZipArchive

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'\n- node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8"))'\n- git diff --check --cached