### PR TITLE
Ignore installed agent skills after setup

### DIFF
--- a/.agents/skills/wp-plugin-bp/SKILL.md
+++ b/.agents/skills/wp-plugin-bp/SKILL.md
@@ -53,10 +53,6 @@ Do not continue with generic WordPress advice when a task applies. The task refe
 
 - `scripts/plugin-replace.php`: deterministic identity replacement and setup cleanup helper. Use this script for initialization and upgrade reference rewrites instead of hand-editing placeholders.
 
-## References
-
-Detailed docs are available as `references/doc-*.mdx`. Installed skills are managed with `npx skills update -p` instead of being committed downstream.
-
 ## Environment
 
 If the host has no working environment (ddev,wp-studio etc) use wp-env.

--- a/.agents/skills/wp-plugin-bp/SKILL.md
+++ b/.agents/skills/wp-plugin-bp/SKILL.md
@@ -55,7 +55,7 @@ Do not continue with generic WordPress advice when a task applies. The task refe
 
 ## References
 
-Detailed docs are available as `references/doc-*.mdx`. In the source repo these may be symlinks into `docs/`; setup removes packaged `.agents/` from initialized plugins, then asks whether to install the current skills with `npx skills add https://github.com/JUVOJustin/wordpress-plugin-boilerplate --skill=*`.
+Detailed docs are available as `references/doc-*.mdx`. In the source repo these may be symlinks into `docs/`; setup removes packaged `.agents/` from initialized plugins, adds `.agents/` to `.gitignore`, then asks whether to install the current skills with `npx skills add https://github.com/JUVOJustin/wordpress-plugin-boilerplate --skill=*`. Installed skills are managed with `npx skills update -p` instead of being committed downstream.
 
 ## Environment
 

--- a/.agents/skills/wp-plugin-bp/SKILL.md
+++ b/.agents/skills/wp-plugin-bp/SKILL.md
@@ -55,7 +55,7 @@ Do not continue with generic WordPress advice when a task applies. The task refe
 
 ## References
 
-Detailed docs are available as `references/doc-*.mdx`. In the source repo these may be symlinks into `docs/`; setup removes packaged `.agents/` from initialized plugins, adds `.agents/` to `.gitignore`, then asks whether to install the current skills with `npx skills add https://github.com/JUVOJustin/wordpress-plugin-boilerplate --skill=*`. Installed skills are managed with `npx skills update -p` instead of being committed downstream.
+Detailed docs are available as `references/doc-*.mdx`. Installed skills are managed with `npx skills update -p` instead of being committed downstream.
 
 ## Environment
 

--- a/.agents/skills/wp-plugin-bp/references/upgrade.md
+++ b/.agents/skills/wp-plugin-bp/references/upgrade.md
@@ -110,9 +110,10 @@ php .agents/skills/wp-plugin-bp/scripts/plugin-replace.php \
     - loader `add_ability()` usage
     - reference docs to consult only: `references/doc-abilities.mdx`
 ### Agent configuration:
-    - `.agents/skills`
-    - prefer `npx skills add https://github.com/JUVOJustin/wordpress-plugin-boilerplate --skill=*` for the boilerplate skill
-    - add new upstream items, update existing items, ask before removing local-only items
+    - do not copy or diff `.agents/skills` as boilerplate source files in downstream plugins
+    - prefer `npx skills update -p` when skills are already installed
+    - use `npx skills add https://github.com/JUVOJustin/wordpress-plugin-boilerplate --skill=*` when the boilerplate skill is missing
+    - ask before removing local-only skills or changing skill install scope
 ### File-control files:
     - `.distignore`
     - `.gitignore`

--- a/.agents/skills/wp-plugin-bp/references/upgrade.md
+++ b/.agents/skills/wp-plugin-bp/references/upgrade.md
@@ -112,7 +112,6 @@ php .agents/skills/wp-plugin-bp/scripts/plugin-replace.php \
 ### Agent configuration:
     - do not copy or diff `.agents/skills` as boilerplate source files in downstream plugins
     - prefer `npx skills update -p` when skills are already installed
-    - use `npx skills add https://github.com/JUVOJustin/wordpress-plugin-boilerplate --skill=*` when the boilerplate skill is missing
     - ask before removing local-only skills or changing skill install scope
 ### File-control files:
     - `.distignore`

--- a/.agents/skills/wp-plugin-bp/scripts/plugin-replace.php
+++ b/.agents/skills/wp-plugin-bp/scripts/plugin-replace.php
@@ -401,6 +401,7 @@ function cleanup_setup_artifacts(string $plugin_path): void
 {
 	reset_docs_directory($plugin_path);
 	cleanup_setup_composer_config($plugin_path);
+	ensure_agents_gitignore_entry($plugin_path);
 	remove_file_if_exists($plugin_path . '/setup.php');
 	remove_file_if_exists($plugin_path . '/src/Cli/Setup.php');
 	remove_file_if_exists($plugin_path . '/context7.json');
@@ -553,6 +554,31 @@ function cleanup_setup_composer_config(string $plugin_path): void
 
 	if (false === file_put_contents($composer_json_path, json_encode($composer_config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL)) {
 		throw new RuntimeException('Unable to write composer.json.');
+	}
+}
+
+/**
+ * Ignore skills installed after setup so downstream plugins manage them through
+ * the skills CLI instead of committing generated copies.
+ *
+ * @param string $plugin_path Plugin root path.
+ *
+ * @return void
+ */
+function ensure_agents_gitignore_entry(string $plugin_path): void
+{
+	$gitignore_path = $plugin_path . '/.gitignore';
+	$contents       = file_exists($gitignore_path) ? (string) file_get_contents($gitignore_path) : '';
+
+	if (preg_match('#^/?\.agents/?$#m', $contents)) {
+		return;
+	}
+
+	$prefix = '' === $contents ? '' : (str_ends_with($contents, PHP_EOL) ? PHP_EOL : PHP_EOL . PHP_EOL);
+	$entry  = $prefix . '# Agent skills are installed and updated with npx skills.' . PHP_EOL . '.agents/' . PHP_EOL;
+
+	if (false === file_put_contents($gitignore_path, $contents . $entry)) {
+		throw new RuntimeException('Unable to write .gitignore.');
 	}
 }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ This plugin is a modern WordPress plugin with strict conventions and automated w
 - **Plugin upgrades**: Use the `wp-plugin-bp` skill or ask naturally to sync with upstream project conventions.
 - **Official WordPress skills**: `.agents/skills/wp-*/` contains focused skills for block development, Interactivity API, PHPStan, project triage, and REST API work. Use the `wp-plugin-bp` skill `wp-skills` workflow to refresh or add official WordPress skills.
 - **Composer setup**: `.agents/` ships in the initial Composer package so setup can run `wp-plugin-bp/scripts/plugin-replace.php`; replacement cleanup removes `.agents/`, then setup asks whether to install agent skills for ongoing work.
+- **Missing skills**: If `wp-plugin-bp` is unavailable in an initialized plugin, install it with `npx skills add https://github.com/JUVOJustin/wordpress-plugin-boilerplate --skill=*`.
 
 ### Maintaining the plugin
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Use this repo when you want to:
 composer create-project juvo/wordpress-plugin-boilerplate
 ```
 
-The setup script asks for the plugin name, namespace, and slug, runs the packaged `wp-plugin-bp` replacement script, removes `.agents/` from the initialized plugin, and adds `.agents/` to the initialized plugin's `.gitignore`.
-After replacement, setup asks whether to install agent skills for ongoing AI-assisted work. Installed skills are managed with `npx skills`, not committed to downstream plugin repositories.
+The setup script asks for the plugin name, namespace, and slug, runs the packaged `wp-plugin-bp` replacement script, and removes `.agents/` from the initialized plugin.
+After replacement, setup asks whether to install agent skills for ongoing AI-assisted work.
 
 ### Common Commands
 
@@ -93,7 +93,6 @@ After replacement, setup asks whether to install agent skills for ongoing AI-ass
 - `AGENTS.md` contains the high-level repository rules and doc map
 - `.agents/skills/wp-plugin-bp/` contains the unified skill, task references, doc snapshots, and scripts
 - `.agents/skills/wp-*/` contains official WordPress skills for block development, Interactivity API, PHPStan, project triage, and REST API work
-- initialized plugins ignore `.agents/`; refresh installed skills with `npx skills update -p`
 - natural requests such as "sync with upstream project conventions" should route through the `wp-plugin-bp` skill and infer the upgrade workflow
 - when repo structure or workflows change, update `README.md`, the relevant files in `docs/`, and `.agents/skills/wp-plugin-bp/`
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Use this repo when you want to:
 composer create-project juvo/wordpress-plugin-boilerplate
 ```
 
-The setup script asks for the plugin name, namespace, and slug, runs the packaged `wp-plugin-bp` replacement script, and removes `.agents/` from the initialized plugin.
-After replacement, setup asks whether to install agent skills for ongoing AI-assisted work.
+The setup script asks for the plugin name, namespace, and slug, runs the packaged `wp-plugin-bp` replacement script, removes `.agents/` from the initialized plugin, and adds `.agents/` to the initialized plugin's `.gitignore`.
+After replacement, setup asks whether to install agent skills for ongoing AI-assisted work. Installed skills are managed with `npx skills`, not committed to downstream plugin repositories.
 
 ### Common Commands
 
@@ -93,6 +93,7 @@ After replacement, setup asks whether to install agent skills for ongoing AI-ass
 - `AGENTS.md` contains the high-level repository rules and doc map
 - `.agents/skills/wp-plugin-bp/` contains the unified skill, task references, doc snapshots, and scripts
 - `.agents/skills/wp-*/` contains official WordPress skills for block development, Interactivity API, PHPStan, project triage, and REST API work
+- initialized plugins ignore `.agents/`; refresh installed skills with `npx skills update -p`
 - natural requests such as "sync with upstream project conventions" should route through the `wp-plugin-bp` skill and infer the upgrade workflow
 - when repo structure or workflows change, update `README.md`, the relevant files in `docs/`, and `.agents/skills/wp-plugin-bp/`
 

--- a/docs/work-with-ai.mdx
+++ b/docs/work-with-ai.mdx
@@ -56,7 +56,9 @@ Agents should infer the right task from natural language. For example, "sync thi
 
 The `wp-plugin-bp` skill is the unified router for plugin workflows. Its `SKILL.md` stays small, command-specific files live in `.agents/skills/wp-plugin-bp/references/`, and detailed docs are linked as `doc-*.mdx` references.
 
-The initial Composer package includes `.agents/` so setup can run `wp-plugin-bp/scripts/plugin-replace.php` for identity replacement. Setup removes `.agents/` after replacement, then asks whether to install agent skills for ongoing AI-assisted work.
+The initial Composer package includes `.agents/` so setup can run `wp-plugin-bp/scripts/plugin-replace.php` for identity replacement. Setup removes `.agents/` after replacement, adds `.agents/` to the initialized plugin's `.gitignore`, then asks whether to install agent skills for ongoing AI-assisted work.
+
+Installed skills are intentionally untracked in initialized plugins. Use `npx skills update -p` to refresh project skills from their upstream source.
 
 ### Skills are not available?
 Install the skills from the upstream repository:


### PR DESCRIPTION
## Summary
- add .agents/ to initialized plugin .gitignore during setup cleanup
- document downstream skill installs as npx skills-managed instead of committed files
- update upgrade guidance to avoid copying/diffing .agents/skills as boilerplate source

## Testing
- php -l .agents/skills/wp-plugin-bp/scripts/plugin-replace.php