### PR TITLE
Add companion-plugin load handshake and version constant

### DIFF
--- a/.agents/skills/wp-plugin-bp/references/upgrade.md
+++ b/.agents/skills/wp-plugin-bp/references/upgrade.md
@@ -101,6 +101,9 @@ php .agents/skills/wp-plugin-bp/scripts/plugin-replace.php \
    - asset enqueueing via entry points
    - block registration
    - loader registration patterns
+### Bootstrap file (the root `@wordpress-plugin` file):
+   - companion-plugin handshake: a `<text_domain_snake>_loaded` action fired on `plugins_loaded` (priority 0), passing the plugin version
+   - the global `<NAMESPACE_UPPER>_VERSION` constant that mirrors the main class `PLUGIN_VERSION` (keep it as the single source of truth; do not add a second version literal)
 ### i18n workflow:
    - `i18n:extract`
    - `i18n:compile`

--- a/demo-plugin.php
+++ b/demo-plugin.php
@@ -45,6 +45,37 @@ define( 'DEMO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 /**
+ * Expose the plugin version as a global constant: the public, convention-following
+ * version contract (cf. WC_VERSION, ELEMENTOR_VERSION). It lets companion plugins
+ * presence-check and version-gate with a cheap defined() / version_compare()
+ * against a stable name, without coupling to the internal Demo_Plugin class, which
+ * core is free to rename or restructure. Derived from the single source of truth,
+ * Demo_Plugin::PLUGIN_VERSION, to avoid version drift.
+ */
+if ( ! defined( 'DEMO_PLUGIN_VERSION' ) ) {
+	define( 'DEMO_PLUGIN_VERSION', Demo_Plugin::PLUGIN_VERSION );
+}
+
+/**
+ * Signal that the plugin is fully loaded so companion plugins can attach to its
+ * extension hooks. Fired on `plugins_loaded` (priority 0) so the handshake is
+ * robust to plugin load order: every active plugin has been included - and had a
+ * chance to register its listener - before the action fires, regardless of which
+ * plugin file WordPress includes first. By the time `plugins_loaded` runs,
+ * demo_plugin_run() has already executed and registered the plugin's hooks during
+ * the include phase.
+ *
+ * @param string $version The current plugin version (Demo_Plugin::PLUGIN_VERSION).
+ */
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		do_action( 'demo_plugin_loaded', Demo_Plugin::PLUGIN_VERSION );
+	},
+	0
+);
+
+/**
  * The code that runs during plugin activation.
  */
 function demo_plugin_activate(): void {

--- a/demo-plugin.php
+++ b/demo-plugin.php
@@ -45,27 +45,20 @@ define( 'DEMO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 /**
- * Expose the plugin version as a global constant: the public, convention-following
- * version contract (cf. WC_VERSION, ELEMENTOR_VERSION). It lets companion plugins
- * presence-check and version-gate with a cheap defined() / version_compare()
- * against a stable name, without coupling to the internal Demo_Plugin class, which
- * core is free to rename or restructure. Derived from the single source of truth,
- * Demo_Plugin::PLUGIN_VERSION, to avoid version drift.
+ * Public version constant for companion plugins to detect this plugin and
+ * version-gate against it. Mirrors Demo_Plugin::PLUGIN_VERSION, the single
+ * source of truth.
  */
 if ( ! defined( 'DEMO_PLUGIN_VERSION' ) ) {
 	define( 'DEMO_PLUGIN_VERSION', Demo_Plugin::PLUGIN_VERSION );
 }
 
 /**
- * Signal that the plugin is fully loaded so companion plugins can attach to its
- * extension hooks. Fired on `plugins_loaded` (priority 0) so the handshake is
- * robust to plugin load order: every active plugin has been included - and had a
- * chance to register its listener - before the action fires, regardless of which
- * plugin file WordPress includes first. By the time `plugins_loaded` runs,
- * demo_plugin_run() has already executed and registered the plugin's hooks during
- * the include phase.
+ * Fires after this plugin has loaded and registered its hooks, so companion
+ * plugins can attach to its extension points. Hooked to `plugins_loaded` to
+ * stay independent of plugin load order.
  *
- * @param string $version The current plugin version (Demo_Plugin::PLUGIN_VERSION).
+ * @param string $version The current plugin version.
  */
 add_action(
 	'plugins_loaded',

--- a/docs/companion-plugins.mdx
+++ b/docs/companion-plugins.mdx
@@ -1,0 +1,71 @@
+---
+title: Companion Plugins
+description: Extend Demo Plugin from a separate plugin using the load handshake and version constant.
+---
+
+The plugin exposes a small, stable surface so a **companion plugin** (for
+example a WPML or WooCommerce integration shipped as its own plugin) can attach
+to it safely, without depending on plugin load order or autoloading the core
+plugin's classes.
+
+Two primitives, both defined in the bootstrap file:
+
+- the `demo_plugin_loaded` **action** — the event "core is ready, attach now"
+- the `DEMO_PLUGIN_VERSION` **constant** — a cheap presence + version check
+
+## The load action
+
+```php title="demo-plugin.php"
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		do_action( 'demo_plugin_loaded', Demo_Plugin::PLUGIN_VERSION );
+	},
+	0
+);
+```
+
+It fires on `plugins_loaded` at priority `0`, and passes the current plugin
+version as its only argument.
+
+## The version constant
+
+```php title="demo-plugin.php"
+if ( ! defined( 'DEMO_PLUGIN_VERSION' ) ) {
+	define( 'DEMO_PLUGIN_VERSION', Demo_Plugin::PLUGIN_VERSION );
+}
+```
+
+`DEMO_PLUGIN_VERSION` is a global mirror of `Demo_Plugin::PLUGIN_VERSION`, which
+stays the single source of truth. It is the *public* version contract — the
+convention WordPress extension developers expect (cf. `WC_VERSION`,
+`ELEMENTOR_VERSION`) — so a companion can presence-check and version-gate with a
+cheap `defined()` / `version_compare()` against a stable name, without coupling
+to the internal `Demo_Plugin` class, which core is free to rename or restructure.
+
+## Writing a companion plugin
+
+```php title="acme-wpml-integration.php"
+// Initialize once the core plugin signals it is fully loaded.
+add_action( 'demo_plugin_loaded', 'acme_wpml_boot' );
+
+function acme_wpml_boot( string $version ): void {
+	// Version-gate against the core plugin's public API.
+	if ( version_compare( $version, '2.0.0', '<' ) ) {
+		return;
+	}
+
+	// ...attach to the core plugin's extension points here.
+}
+```
+
+A companion that initializes *after* `plugins_loaded` priority `0` (rare, but
+e.g. during late init) can detect core synchronously via the constant and the
+`did_action()` guard instead of waiting:
+
+```php title="acme-wpml-integration.php"
+if ( did_action( 'demo_plugin_loaded' )
+	&& version_compare( DEMO_PLUGIN_VERSION, '2.0.0', '>=' ) ) {
+	acme_wpml_boot( DEMO_PLUGIN_VERSION );
+}
+```

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -48,6 +48,7 @@ This boilerplate gives you a structured starting point for building modern WordP
 | scaffold and register Gutenberg blocks | [create-blocks.mdx](./create-blocks.mdx) |
 | register WordPress abilities | [abilities.mdx](./abilities.mdx) |
 | wire in translation extraction and compilation | [i18n.mdx](./i18n.mdx) |
+| expose load hooks for companion plugins | [companion-plugins.mdx](./companion-plugins.mdx) |
 
 ### Add Integrations
 

--- a/tests/php/CompanionHandshakeTest.php
+++ b/tests/php/CompanionHandshakeTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Tests for the companion-plugin handshake exposed by the bootstrap.
+ *
+ * Covers the `demo_plugin_loaded` action and the `DEMO_PLUGIN_VERSION` constant
+ * defined in demo-plugin.php.
+ *
+ * @package Demo_Plugin
+ */
+
+use Demo_Plugin\Demo_Plugin;
+
+/**
+ * Verifies the load handshake companion plugins rely on.
+ */
+class CompanionHandshakeTest extends WP_UnitTestCase {
+
+	/**
+	 * The global version constant must mirror the single source of truth so
+	 * companions can version-gate without autoloading the plugin's classes.
+	 */
+	public function test_version_constant_mirrors_class_constant(): void {
+		$this->assertTrue( defined( 'DEMO_PLUGIN_VERSION' ), 'DEMO_PLUGIN_VERSION should be defined by the bootstrap.' );
+		$this->assertSame( Demo_Plugin::PLUGIN_VERSION, DEMO_PLUGIN_VERSION );
+	}
+
+	/**
+	 * The handshake must actually fire during a real WordPress load, after
+	 * plugins are included (it is hooked to `plugins_loaded`).
+	 */
+	public function test_loaded_action_fires_on_bootstrap(): void {
+		$this->assertGreaterThan( 0, did_action( 'demo_plugin_loaded' ) );
+	}
+
+	/**
+	 * The action must pass the current plugin version to its listeners.
+	 *
+	 * Re-dispatching `plugins_loaded` runs the bootstrap's priority-0 callback
+	 * again so the argument it forwards can be observed.
+	 */
+	public function test_loaded_action_passes_plugin_version(): void {
+		$received = array();
+		add_action(
+			'demo_plugin_loaded',
+			static function ( $version ) use ( &$received ): void {
+				$received[] = $version;
+			}
+		);
+
+		do_action( 'plugins_loaded' );
+
+		$this->assertNotEmpty( $received, 'demo_plugin_loaded should fire when plugins_loaded runs.' );
+		$this->assertSame( Demo_Plugin::PLUGIN_VERSION, end( $received ) );
+	}
+}


### PR DESCRIPTION
## Summary
Adds a companion-plugin handshake to the bootstrap so a separate plugin (e.g. a WPML or WooCommerce integration) can extend this plugin safely, independent of plugin load order.

- **`demo_plugin_loaded` action** — fired on `plugins_loaded` (priority 0) after the bootstrap wires the plugin's hooks; passes the plugin version. Firing on `plugins_loaded` runs after the synchronous `run()` wiring while still guaranteeing every active plugin has been included, so no companion misses the handshake regardless of include order.
- **`DEMO_PLUGIN_VERSION` constant** — global mirror of `Demo_Plugin::PLUGIN_VERSION` (kept as the single source of truth). The conventional public version contract (cf. `WC_VERSION`) for cheap `defined()` / `version_compare()` checks without coupling callers to internal classes.

Both tokens rewrite correctly at setup (`demo_plugin_loaded` → `<text_domain>_loaded`, `DEMO_PLUGIN_VERSION` → `<NAMESPACE_UPPER>_VERSION`).

## Test plan
- `tests/php/CompanionHandshakeTest.php` — asserts the constant mirrors the class constant, the action fires during bootstrap, and it forwards the version. `npm run test:php` → **OK (4 tests, 6 assertions)**.
- `composer run phpstan` and `vendor/bin/phpcs` — clean.

## Docs
- New `docs/companion-plugins.mdx` (+ nav link in `docs/index.mdx`).
- Skill `upgrade` reference lists the bootstrap handshake as an upgradable part so downstream plugins adopt it on sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
