### PR TITLE
Add registration regression tests for blocks and abilities

### DIFF
--- a/.agents/skills/wp-plugin-bp/references/abilities.md
+++ b/.agents/skills/wp-plugin-bp/references/abilities.md
@@ -9,3 +9,4 @@ Implement or update WordPress Abilities API code.
 3. Register abilities through the Loader with `add_ability()`.
 4. Do not register hooks in constructors.
 5. Keep schema, permissions, and callbacks close to the owning ability class.
+6. Verify with `npm run test:php` — `tests/php/AbilityRegistrationTest.php` checks every `Ability_Interface` implementation (and its category) is registered. No edits needed when adding abilities.

--- a/.agents/skills/wp-plugin-bp/references/blocks.md
+++ b/.agents/skills/wp-plugin-bp/references/blocks.md
@@ -9,3 +9,4 @@ Create or maintain Gutenberg blocks in this plugin.
 3. Keep block source under the established resources or blocks layout.
 4. Ensure block manifests are included in production builds.
 5. Run `npm run build` after block changes.
+6. Verify loading with `npm run test:php` — `tests/php/BlockRegistrationTest.php` checks every built block is registered (via `/wp/v2/block-types`) and its assets exist. No edits needed when adding blocks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This plugin is a modern WordPress plugin with strict conventions and automated w
 
 ### Feature Quick Reference
 
-- **Blocks**: Run `npm run create-block`. Use the `wp-plugin-bp` skill for block guidance.
+- **Blocks**: Run `npm run create-block`. Registration is automatic; `tests/php/BlockRegistrationTest.php` generically guards that every built block is loaded (via `/wp/v2/block-types`) and its assets exist. Use the `wp-plugin-bp` skill for block guidance.
 - **Abilities API**: Implement interfaces in `src/Abilities/`, register via Loader. Use the `wp-plugin-bp` skill for ability guidance.
 - **i18n**: Extract with `composer run i18n:extract`, compile with `composer run i18n:compile`. Use the `wp-plugin-bp` skill for translation work.
 - **wp-env**: Start with `npm run env:start`. Use the `wp-plugin-bp` skill when tests are involved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This plugin is a modern WordPress plugin with strict conventions and automated w
 ### Feature Quick Reference
 
 - **Blocks**: Run `npm run create-block`. Registration is automatic; `tests/php/BlockRegistrationTest.php` generically guards that every built block is loaded (via `/wp/v2/block-types`) and its assets exist. Use the `wp-plugin-bp` skill for block guidance.
-- **Abilities API**: Implement interfaces in `src/Abilities/`, register via Loader. Use the `wp-plugin-bp` skill for ability guidance.
+- **Abilities API**: Implement interfaces in `src/Abilities/`, register via Loader. `tests/php/AbilityRegistrationTest.php` generically guards that every `Ability_Interface` implementation (and its category) is registered. Use the `wp-plugin-bp` skill for ability guidance.
 - **i18n**: Extract with `composer run i18n:extract`, compile with `composer run i18n:compile`. Use the `wp-plugin-bp` skill for translation work.
 - **wp-env**: Start with `npm run env:start`. Use the `wp-plugin-bp` skill when tests are involved.
 - **Testing**: Run application tests with `npm run test:php`. Use the `wp-plugin-bp` skill for testing guidance.

--- a/docs/abilities.mdx
+++ b/docs/abilities.mdx
@@ -144,6 +144,12 @@ $this->loader->add_ability( Abilities\My_Ability::class );
 
 Categories are automatically registered via the Loader when abilities reference them.
 
+### Registration is guarded by a test
+
+Because registration is manual, the easy mistake is writing an ability class but forgetting the `add_ability()` call — it then silently does nothing. `tests/php/AbilityRegistrationTest.php` guards against this: it discovers **every** class implementing `Ability_Interface` (by reflection, so it survives the setup rename) and asserts each one — and its category — is present in the live Abilities API registry (`wp_get_ability()` / `wp_get_ability_category()`).
+
+The test needs no changes when you add abilities, and is skipped when none exist or on WordPress &lt; 6.9. Run it with `npm run test:php`.
+
 ## Ability Interface Reference
 
 | Method | Returns | Purpose |

--- a/docs/create-blocks.mdx
+++ b/docs/create-blocks.mdx
@@ -21,6 +21,12 @@ To make this work the `npm run start` and `npm run build` scripts make use of th
 
 Luckily this is all done for you automatically! No need for any manual registration or code.
 
+## Block loading is guarded by a test
+
+Because registration is fully automatic, it is easy to break loading without an obvious error (forgetting `npm run build`, an invalid `block.json`, or referencing an asset file that was never built). `tests/php/BlockRegistrationTest.php` guards against this generically: it discovers **every** block in `build/Blocks` and asserts each one is reported by the editor-facing `/wp/v2/block-types` REST endpoint and that every script/style declared in its `block.json` exists in the build output.
+
+The test needs no changes when you add or rename blocks, and is skipped when no blocks are built. Run it with `npm run test:php` (after `npm run build`).
+
 ## Using webpack-entrypoints styles in the editor
 There may be situations where you want to use styles defined in the `webpack-entrypoints` files in the block editor.
 For example if you want the styling of your block to be the same on frontend and backend but also requires e.g. variables from the plugins global styles.

--- a/tests/php/AbilityRegistrationTest.php
+++ b/tests/php/AbilityRegistrationTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Ensures every ability defined in code is registered with the WordPress Abilities API.
+ *
+ * Unlike blocks, abilities are not registered automatically: each ability is a plain PHP
+ * class implementing Ability_Interface that must be wired up by hand via
+ * `$loader->add_ability()` in the plugin's main class. The easy mistake is writing the
+ * ability class but forgetting to register it — it then silently does nothing.
+ *
+ * Because the interface is strict (a static `get_name()` and `get_category()`), every
+ * ability can be discovered by reflection and checked against the live registry. This
+ * guard discovers every Ability_Interface implementation in the codebase and asserts
+ * WordPress knows about it and its category.
+ *
+ * It needs no edits when abilities are added, and is skipped when none exist (the fresh
+ * boilerplate state) or when the Abilities API is unavailable (WordPress < 6.9).
+ *
+ * @package Demo_Plugin
+ */
+
+use Demo_Plugin\Abilities\Ability_Interface;
+
+/**
+ * Verifies the manual ability registration wiring end-to-end.
+ */
+class AbilityRegistrationTest extends WP_UnitTestCase {
+
+	/**
+	 * Every Ability_Interface implementation must be registered with WordPress.
+	 */
+	public function test_defined_abilities_are_registered(): void {
+		$this->require_abilities_api();
+
+		foreach ( $this->discover_abilities() as $ability ) {
+			$this->assertNotNull(
+				wp_get_ability( $ability::get_name() ),
+				sprintf(
+					'Ability "%s" implements Ability_Interface but is not registered. Did you call $this->loader->add_ability( %s::class ) in the plugin main class?',
+					$ability::get_name(),
+					$ability
+				)
+			);
+		}
+	}
+
+	/**
+	 * Each ability's declared category must also be registered.
+	 */
+	public function test_ability_categories_are_registered(): void {
+		$this->require_abilities_api();
+
+		foreach ( $this->discover_abilities() as $ability ) {
+			$category = $ability::get_category();
+
+			$this->assertNotNull(
+				wp_get_ability_category( $category::get_slug() ),
+				sprintf(
+					'Ability "%s" declares category "%s" but that category is not registered.',
+					$ability::get_name(),
+					$category::get_slug()
+				)
+			);
+		}
+	}
+
+	/**
+	 * Discover every concrete Ability_Interface implementation in the codebase.
+	 *
+	 * The abilities directory and namespace are derived from the interface itself, so this
+	 * keeps working after the boilerplate's namespace is renamed during setup. Skips the
+	 * test when no abilities exist yet.
+	 *
+	 * @return array<int, class-string<Ability_Interface>>
+	 */
+	private function discover_abilities(): array {
+		$interface = new ReflectionClass( Ability_Interface::class );
+		$base_ns   = $interface->getNamespaceName();
+		$dir       = dirname( (string) $interface->getFileName() );
+
+		$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS ) );
+
+		$abilities = array();
+		foreach ( $iterator as $file ) {
+			if ( 'php' !== $file->getExtension() ) {
+				continue;
+			}
+
+			$relative = substr( $file->getPathname(), strlen( $dir ) + 1, - strlen( '.php' ) );
+			$class    = $base_ns . '\\' . str_replace( '/', '\\', $relative );
+
+			// class_exists autoloads and returns false for interfaces/traits and any
+			// file whose class name does not follow PSR-4, excluding them naturally.
+			if ( ! class_exists( $class ) || ! is_subclass_of( $class, Ability_Interface::class ) ) {
+				continue;
+			}
+
+			if ( ( new ReflectionClass( $class ) )->isAbstract() ) {
+				continue;
+			}
+
+			$abilities[] = $class;
+		}
+
+		if ( empty( $abilities ) ) {
+			$this->markTestSkipped( sprintf( 'No Ability_Interface implementations found in %s.', $dir ) );
+		}
+
+		return $abilities;
+	}
+
+	/**
+	 * Skip the test when the Abilities API (WordPress 6.9+) is not loaded.
+	 */
+	private function require_abilities_api(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'The WordPress Abilities API (WP 6.9+) is not available in this environment.' );
+		}
+	}
+}

--- a/tests/php/BlockRegistrationTest.php
+++ b/tests/php/BlockRegistrationTest.php
@@ -34,26 +34,18 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 	);
 
 	/**
-	 * Spin up a REST server and authenticate as an administrator.
-	 *
-	 * The /wp/v2/block-types endpoint requires the `edit_posts` capability, so a
-	 * privileged user must be the current user for the request to succeed.
+	 * Every built block must be reported as registered by the REST API.
 	 */
-	public function set_up(): void {
-		parent::set_up();
+	public function test_built_blocks_are_registered(): void {
+		$blocks = $this->discover_blocks();
 
+		// The /wp/v2/block-types endpoint needs a running REST server and the
+		// `edit_posts` capability, so set both up just for this test.
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		global $wp_rest_server;
 		$wp_rest_server = new \WP_REST_Server();
 		do_action( 'rest_api_init' );
-	}
-
-	/**
-	 * Every built block must be reported as registered by the REST API.
-	 */
-	public function test_built_blocks_are_registered(): void {
-		$blocks = $this->discover_blocks();
 
 		$response = rest_do_request( new \WP_REST_Request( 'GET', '/wp/v2/block-types' ) );
 		$this->assertSame( 200, $response->get_status(), 'The /wp/v2/block-types endpoint should respond with HTTP 200.' );
@@ -74,8 +66,13 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 
 	/**
 	 * Every asset declared by a built block must exist on disk so it cannot 404.
+	 *
+	 * Missing assets are collected and asserted once so the test always makes an
+	 * assertion (never "risky"), even for blocks that declare no file-based assets.
 	 */
 	public function test_built_block_assets_exist(): void {
+		$missing = array();
+
 		foreach ( $this->discover_blocks() as $block ) {
 			foreach ( self::ASSET_FIELDS as $field ) {
 				if ( ! isset( $block['metadata'][ $field ] ) ) {
@@ -88,18 +85,18 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 					}
 
 					$path = $block['dir'] . '/' . ltrim( substr( $ref, strlen( 'file:' ) ), './' );
-					$this->assertFileExists(
-						$path,
-						sprintf(
-							'Block "%s" declares %s "%s" but the built file is missing — it will 404 when enqueued. Run `npm run build`.',
-							$block['name'],
-							$field,
-							$ref
-						)
-					);
+					if ( ! file_exists( $path ) ) {
+						$missing[] = sprintf( '%s declares %s "%s"', $block['name'], $field, $ref );
+					}
 				}
 			}
 		}
+
+		$this->assertSame(
+			array(),
+			$missing,
+			"Some built blocks declare assets missing from the build output — they will 404 when enqueued. Run `npm run build`.\n" . implode( "\n", $missing )
+		);
 	}
 
 	/**

--- a/tests/php/BlockRegistrationTest.php
+++ b/tests/php/BlockRegistrationTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Ensures every block shipped in the build output is actually loaded by WordPress.
+ *
+ * Blocks are registered automatically from `build/blocks-manifest.php` via
+ * Demo_Plugin::register_blocks() on the `init` hook. This generic guard discovers
+ * every block in `build/Blocks` and asserts that:
+ *   1. WordPress reports it through the editor-facing REST API (/wp/v2/block-types), and
+ *   2. each asset file referenced in its block.json exists in the build output.
+ *
+ * It needs no edits when blocks are added or renamed, and is skipped when no blocks
+ * are present (the fresh boilerplate state).
+ *
+ * @package Demo_Plugin
+ */
+
+/**
+ * Verifies the automatic block registration pipeline end-to-end.
+ */
+class BlockRegistrationTest extends WP_UnitTestCase {
+
+	/**
+	 * Block.json fields that may reference script/style assets.
+	 *
+	 * @var string[]
+	 */
+	private const ASSET_FIELDS = array(
+		'editorScript',
+		'script',
+		'viewScript',
+		'editorStyle',
+		'style',
+		'viewStyle',
+	);
+
+	/**
+	 * Spin up a REST server and authenticate as an administrator.
+	 *
+	 * The /wp/v2/block-types endpoint requires the `edit_posts` capability, so a
+	 * privileged user must be the current user for the request to succeed.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Every built block must be reported as registered by the REST API.
+	 */
+	public function test_built_blocks_are_registered(): void {
+		$blocks = $this->discover_blocks();
+
+		$response = rest_do_request( new \WP_REST_Request( 'GET', '/wp/v2/block-types' ) );
+		$this->assertSame( 200, $response->get_status(), 'The /wp/v2/block-types endpoint should respond with HTTP 200.' );
+
+		$registered = wp_list_pluck( $response->get_data(), 'name' );
+
+		foreach ( $blocks as $block ) {
+			$this->assertContains(
+				$block['name'],
+				$registered,
+				sprintf(
+					'Block "%s" exists in build/Blocks but the REST API does not report it as registered. Did `init`/register_blocks() wire it up? Try running `npm run build`.',
+					$block['name']
+				)
+			);
+		}
+	}
+
+	/**
+	 * Every asset declared by a built block must exist on disk so it cannot 404.
+	 */
+	public function test_built_block_assets_exist(): void {
+		foreach ( $this->discover_blocks() as $block ) {
+			foreach ( self::ASSET_FIELDS as $field ) {
+				if ( ! isset( $block['metadata'][ $field ] ) ) {
+					continue;
+				}
+
+				foreach ( (array) $block['metadata'][ $field ] as $ref ) {
+					if ( ! is_string( $ref ) || ! str_starts_with( $ref, 'file:' ) ) {
+						continue;
+					}
+
+					$path = $block['dir'] . '/' . ltrim( substr( $ref, strlen( 'file:' ) ), './' );
+					$this->assertFileExists(
+						$path,
+						sprintf(
+							'Block "%s" declares %s "%s" but the built file is missing — it will 404 when enqueued. Run `npm run build`.',
+							$block['name'],
+							$field,
+							$ref
+						)
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Discover every block in the build output, skipping the test when none exist.
+	 *
+	 * @return array<int, array{name: string, dir: string, metadata: array<string, mixed>}>
+	 */
+	private function discover_blocks(): array {
+		$blocks_dir = DEMO_PLUGIN_PATH . 'build/Blocks';
+
+		if ( ! is_dir( $blocks_dir ) ) {
+			$this->markTestSkipped( 'No build/Blocks directory found. Add a block with `npm run create-block` and run `npm run build`.' );
+		}
+
+		$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $blocks_dir, FilesystemIterator::SKIP_DOTS ) );
+
+		$blocks = array();
+		foreach ( $iterator as $file ) {
+			if ( 'block.json' !== $file->getFilename() ) {
+				continue;
+			}
+
+			$metadata = json_decode( (string) file_get_contents( $file->getPathname() ), true );
+
+			$this->assertIsArray(
+				$metadata,
+				sprintf( 'block.json at "%s" is not valid JSON.', $file->getPathname() )
+			);
+			$this->assertNotEmpty(
+				$metadata['name'] ?? null,
+				sprintf( 'block.json at "%s" is missing a "name". WordPress cannot register an unnamed block.', $file->getPathname() )
+			);
+
+			$blocks[] = array(
+				'name'     => $metadata['name'],
+				'dir'      => $file->getPath(),
+				'metadata' => $metadata,
+			);
+		}
+
+		if ( empty( $blocks ) ) {
+			$this->markTestSkipped( 'No block.json files found in build/Blocks. Run `npm run build` after adding a block.' );
+		}
+
+		return $blocks;
+	}
+}


### PR DESCRIPTION
## What

Two generic, zero-maintenance guards that the plugin's auto/loader-registered primitives actually load in WordPress. Both read everything at runtime (no hardcoded names), survive `setup` renaming, need no edits when primitives are added, and skip cleanly when none exist.

### `tests/php/BlockRegistrationTest.php`

Block registration is automatic (`wp_register_block_types_from_metadata_collection()` on `init`). For every block in `build/Blocks` the test:
1. **Registration** — asserts it's reported by the editor-facing `/wp/v2/block-types` REST endpoint.
2. **Assets** — asserts every `file:` script/style in its `block.json` exists in the build output (so a block can't register cleanly while its JS/CSS 404s).

Skipped when no blocks are built (fresh boilerplate).

### `tests/php/AbilityRegistrationTest.php`

Ability registration is **manual** (`$loader->add_ability()`), so the easy mistake is writing an `Ability_Interface` class and forgetting to wire it. The test discovers every `Ability_Interface` implementation by reflection (deriving the directory + namespace from the interface itself, so it survives the namespace rename) and asserts each ability **and its category** exist in the live registry (`wp_get_ability()` / `wp_get_ability_category()`).

Skipped when no abilities exist or on WordPress < 6.9.

## Verification (in wp-env)

- **Blocks:** scaffolded a block + `npm run build` → both checks pass; corrupting the block `name` or deleting a built asset fails with a descriptive message.
- **Abilities:** wired a sample ability → both checks pass; removing the `add_ability()` call fails with `Ability "…" implements Ability_Interface but is not registered. Did you call $this->loader->add_ability(…)?`.

Both checks use in-process dispatch (`rest_do_request()` / registry functions) and filesystem reads — no HTTP port, so they're unaffected by wp-env `--autoport`.

## Docs

- Notes in `docs/create-blocks.mdx` and `docs/abilities.mdx` (symlinked into the `wp-plugin-bp` skill).
- Pointers in `AGENTS.md` and the skill's `blocks.md` / `abilities.md` workflows.