### PR TITLE
Rename and rewrite translation files during plugin setup

### DIFF
--- a/.agents/skills/wp-plugin-bp/scripts/plugin-replace.php
+++ b/.agents/skills/wp-plugin-bp/scripts/plugin-replace.php
@@ -129,6 +129,8 @@ function apply_replacements(string $plugin_path, string $plugin_name, string $pl
 				'.*\.json',
 				'.*\.github\/.*\.(yml|md)',
 				'.*\.neon',
+				'.*\.po',
+				'.*\.pot',
 			),
 			$md_patterns
 		)
@@ -189,12 +191,15 @@ function apply_replacements(string $plugin_path, string $plugin_name, string $pl
 				'.*\.php',
 				'.*README\.txt',
 				'.*\.github\/.*\.(yml|md)',
+				'.*\.po',
+				'.*\.pot',
 			),
 			$md_patterns
 		)
 	);
 
 	rename_template_files($plugin_path, $plugin_namespace, $plugin_slug, $source_namespace, $source_slug);
+	rename_translation_files($plugin_path, $plugin_slug, $source_slug);
 	remove_setup_docs($plugin_path);
 }
 
@@ -317,6 +322,49 @@ function rename_template_files(string $plugin_path, string $plugin_namespace, st
 {
 	rename_if_exists($plugin_path . "/src/{$source_namespace}.php", $plugin_path . "/src/{$plugin_namespace}.php");
 	rename_if_exists($plugin_path . "/{$source_slug}.php", $plugin_path . "/{$plugin_slug}.php");
+}
+
+/**
+ * Rename translation files in languages/ that are prefixed with the source slug.
+ *
+ * Covers the POT template ("{slug}.pot") plus any shipped locale catalogs
+ * ("{slug}-{locale}.po|mo|json|l10n.php"). WordPress resolves translations by
+ * the "{text-domain}-{locale}" filename convention, so these must follow the
+ * new slug or they will never load.
+ *
+ * @param string $plugin_path Plugin root path.
+ * @param string $plugin_slug Plugin slug.
+ * @param string $source_slug Source slug currently used in file names.
+ *
+ * @return void
+ */
+function rename_translation_files(string $plugin_path, string $plugin_slug, string $source_slug): void
+{
+	if ($plugin_slug === $source_slug) {
+		return;
+	}
+
+	$languages_path = $plugin_path . '/languages';
+	if (! is_dir($languages_path)) {
+		return;
+	}
+
+	foreach (new DirectoryIterator($languages_path) as $item) {
+		if ($item->isDot() || ! $item->isFile()) {
+			continue;
+		}
+
+		$filename = $item->getFilename();
+
+		// Match "{slug}.<ext>" or "{slug}-<rest>" so we never touch an unrelated
+		// file that merely starts with the same characters.
+		if ($filename !== $source_slug && 0 !== strpos($filename, $source_slug . '.') && 0 !== strpos($filename, $source_slug . '-')) {
+			continue;
+		}
+
+		$new_filename = $plugin_slug . substr($filename, strlen($source_slug));
+		rename_if_exists($item->getPathname(), $languages_path . '/' . $new_filename);
+	}
 }
 
 /**


### PR DESCRIPTION
## Problem

The setup replace script (`plugin-replace.php`) never touched `languages/`. After a developer initialized the boilerplate with a new text domain, the shipped `languages/demo-plugin.pot` (and the sample `demo-plugin-fr_FR.mo`) were left behind:

- The `.pot`/`.mo` filenames still used the `demo-plugin` slug, so WordPress (`load_plugin_textdomain('<new-slug>', .../languages/')`) would never load them.
- The POT internals were stale: `X-Domain: demo-plugin`, `Project-Id-Version: Demo Plugin 1.0.0`, support URL, and `#: demo-plugin.php` source refs (a file that gets renamed during setup).

The `i18n:extract` command in `composer.json` *was* updated (it's covered by the `*.json` rule), so extraction self-heals the active file — but the orphaned `demo-plugin.*` files remained.

## Fix

- Add `.po`/`.pot` to the slug and human-name replacement sets so POT headers and source references follow the new plugin identity.
- Add `rename_translation_files()` to rename `languages/{slug}.pot` and `{slug}-{locale}.(po|mo|json|l10n.php)` to the new slug. Strict `slug.`/`slug-` prefix match; no-ops when the slug is unchanged or `languages/` is absent.

## Verification

Ran the script against a temp tree with the real `demo-plugin.pot`/`.mo`:
- Files renamed to `my-plugin.pot` / `my-plugin-fr_FR.mo`.
- Headers rewritten: `Project-Id-Version: My Plugin 1.0.0`, `X-Domain: my-plugin`, support URL, `#: my-plugin.php`.
- No remaining `demo-plugin` references in `languages/`.
- `php -l` clean.

## Note

This edits the downstream-distributable copy under `.agents/`. If the upstream `wp-plugin-bp` skill source is maintained separately, the same change should be mirrored there.