### PR TITLE
Add MCP exposure config to Ability_Interface

### DIFF
--- a/docs/abilities.mdx
+++ b/docs/abilities.mdx
@@ -118,6 +118,12 @@ class My_Ability implements Ability_Interface {
         return true;
     }
 
+    public static function get_mcp(): array {
+        // Expose this ability on the MCP Adapter's default server. Return an empty
+        // array instead to keep it off MCP (it can still be added to a custom server).
+        return array( 'public' => true );
+    }
+
     public static function check_permissions( mixed $input = null ): bool|WP_Error {
         return current_user_can( 'read' );
     }
@@ -162,6 +168,7 @@ The test needs no changes when you add abilities, and is skipped when none exist
 | `get_output_schema()` | `array` | JSON Schema for output |
 | `get_annotations()` | `array` | Behavioral hints (readonly, destructive, idempotent) |
 | `show_rest()` | `bool` | Expose via REST API |
+| `get_mcp()` | `array` | MCP exposure config, registered as `meta.mcp` |
 | `check_permissions($input)` | `bool\|WP_Error` | Permission check |
 | `execute($input)` | `mixed` | Main logic |
 

--- a/src/Abilities/Ability_Interface.php
+++ b/src/Abilities/Ability_Interface.php
@@ -93,6 +93,18 @@ interface Ability_Interface {
 	public static function show_rest(): bool;
 
 	/**
+	 * Get the MCP (Model Context Protocol) exposure configuration
+	 *
+	 * Registered as the ability's `meta.mcp` for the WordPress MCP Adapter. Set `public` to
+	 * `true` to expose the ability on the adapter's default server; the default empty array
+	 * keeps it off.
+	 *
+	 * @return array{public?: bool} Configuration registered as the ability's `meta.mcp`.
+	 * @see https://developer.wordpress.org/news/2026/02/from-abilities-to-ai-agents-introducing-the-wordpress-mcp-adapter/ MCP Adapter.
+	 */
+	public static function get_mcp(): array;
+
+	/**
 	 * Check if the current user can execute this ability
 	 *
 	 * @param mixed $input Optional. The input data for the ability.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -287,6 +287,7 @@ class Loader {
 					'meta'                => array(
 						'annotations'  => $ability_class::get_annotations(),
 						'show_in_rest' => $ability_class::show_rest(),
+						'mcp'          => $ability_class::get_mcp(),
 					),
 				)
 			);


### PR DESCRIPTION
Expose abilities to the WordPress MCP Adapter via a new get_mcp() interface method, registered verbatim as the ability's meta.mcp. It returns an array (shape array{public?: bool}, enforced by PHPStan) rather than a bool so future MCP options extend the shape instead of the interface.