### PR TITLE
Build Interactivity API modules via --experimental-modules

### DIFF
--- a/.agents/skills/wp-plugin-bp/references/bundling.md
+++ b/.agents/skills/wp-plugin-bp/references/bundling.md
@@ -7,6 +7,10 @@ Work on wp-scripts bundling, entry points, assets, and enqueueing.
 1. Load `references/doc-bundling.mdx`.
 2. Put admin assets in `resources/admin/`.
 3. Put frontend assets in `resources/frontend/`.
-4. Add or adjust entry points in `webpack.config.js`.
+4. Add or adjust entry points in `webpack.config.js`. Only augment the classic
+   script config &mdash; skip configs where `config.experiments?.outputModule` is set,
+   since that is the ESM module build for Interactivity API `viewScriptModule`
+   (`view.js`) modules and must stay untouched.
 5. Enqueue compiled entry points through the plugin's established enqueue helper.
-6. Run `npm run build` before finishing.
+6. Run `npm run build` before finishing. `start`/`build` use `--experimental-modules`
+   so the Interactivity API module build is produced.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This plugin is a modern WordPress plugin with strict conventions and automated w
 
 - **Assets**: Place in `resources/admin/` and `resources/frontend/`.
 - **Build**: `@wordpress/scripts` handles compilation. Entry points in `webpack.config.js`.
-- **Scripts**: `npm run start` (watch), `npm run build` (production). Both pass `--experimental-modules` so the Interactivity API ESM module build (`viewScriptModule`/`view.js`) is produced; `extendConfig` in `webpack.config.js` leaves that config untouched.
+- **Scripts**: `npm run start` (watch), `npm run build` (production).
 
 ### Quality Assurance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This plugin is a modern WordPress plugin with strict conventions and automated w
 
 - **Assets**: Place in `resources/admin/` and `resources/frontend/`.
 - **Build**: `@wordpress/scripts` handles compilation. Entry points in `webpack.config.js`.
-- **Scripts**: `npm run start` (watch), `npm run build` (production).
+- **Scripts**: `npm run start` (watch), `npm run build` (production). Both pass `--experimental-modules` so the Interactivity API ESM module build (`viewScriptModule`/`view.js`) is produced; `extendConfig` in `webpack.config.js` leaves that config untouched.
 
 ### Quality Assurance
 

--- a/docs/bundeling.mdx
+++ b/docs/bundeling.mdx
@@ -21,6 +21,12 @@ The project uses `@wordpress/scripts` (wp-scripts) for bundling and compiling fr
 | `npm run format` | Format JavaScript files using Prettier |
 | `npm run packages-update` | Update WordPress packages to latest versions |
 
+### Interactivity API modules
+
+`start` and `build` pass `--experimental-modules`, which is required for the [Interactivity API](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/). With this flag, wp-scripts emits **two** webpack configs &mdash; the classic script build plus an ESM module build that compiles block `viewScriptModule` (`view.js`) modules. Without it, those modules are never built and interactive blocks silently ship without their frontend behavior.
+
+The `extendConfig` helper in `webpack.config.js` augments only the classic script build (jQuery shim + custom entries) and passes the ESM module config through untouched, so the module build stays clean. The flag is harmless when the plugin has no interactive blocks.
+
 ## Directory Structure
 
 The `resources/` folder contains source assets and is excluded from distribution. The `build/` folder contains compiled assets.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "@wordpress/scripts": "^32.1.0"
   },
   "scripts": {
-    "start": "wp-scripts start --blocks-manifest",
-    "build": "wp-scripts build --blocks-manifest",
+    "start": "wp-scripts start --blocks-manifest --experimental-modules",
+    "build": "wp-scripts build --blocks-manifest --experimental-modules",
     "lint:style": "wp-scripts lint-style 'resources/**/*.{css,scss,sass}'",
     "lint:js": "wp-scripts lint-js ./resources",
     "lint:fix:js": "wp-scripts lint-js ./resources --fix",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,23 +14,38 @@ const customEntries = {
 	],
 };
 
-/** Preserves wp-scripts' auto-discovered block entries while adding custom ones. */
-const extendConfig = ( config ) => ( {
-	...config,
-	plugins: [
-		...config.plugins,
-		new webpack.ProvidePlugin( {
-			$: 'jquery',
-			jQuery: 'jquery',
-		} ),
-	],
-	entry: {
-		...( typeof config.entry === 'function'
-			? config.entry()
-			: config.entry ),
-		...customEntries,
-	},
-} );
+/**
+ * Preserves wp-scripts' auto-discovered block entries while adding custom ones.
+ *
+ * With `--experimental-modules`, wp-scripts exports an array of two configs: the
+ * classic script config and an ESM module config (`experiments.outputModule`) that
+ * compiles Interactivity API `viewScriptModule`/`view.js` modules. The jQuery provide
+ * shim and the custom script/style entries belong only to the classic script build, so
+ * the ESM module config is passed through untouched. Injecting jQuery or the SCSS/admin
+ * entries there would break the Interactivity API `view.js` module build.
+ */
+const extendConfig = ( config ) => {
+	if ( config.experiments?.outputModule ) {
+		return config;
+	}
+
+	return {
+		...config,
+		plugins: [
+			...config.plugins,
+			new webpack.ProvidePlugin( {
+				$: 'jquery',
+				jQuery: 'jquery',
+			} ),
+		],
+		entry: {
+			...( typeof config.entry === 'function'
+				? config.entry()
+				: config.entry ),
+			...customEntries,
+		},
+	};
+};
 
 module.exports = Array.isArray( defaultConfig )
 	? defaultConfig.map( extendConfig )


### PR DESCRIPTION
## Summary

Pass `--experimental-modules` to `wp-scripts start`/`build` so wp-scripts emits its ESM module config, and guard `extendConfig` so it only touches the classic script build.

### Why

Verified against the installed `@wordpress/scripts@32.1.0` source:

- `getWebpackArgs()` only sets `WP_EXPERIMENTAL_MODULES=true` when `--experimental-modules` is passed (`utils/config.js:123`).
- The default webpack config only exports the two-config array `[scriptConfig, moduleConfig]` when that env is set; otherwise it exports a single classic `scriptConfig` (`config/webpack.config.js:507-509`).
- Only `moduleConfig` has `experiments.outputModule: true` and compiles block `viewScriptModule` (`view.js`) modules used by the **Interactivity API**.

**Without the flag, those modules are never emitted — interactive blocks silently ship without their frontend behavior.**

### The `extendConfig` guard

The config already maps over the array but applied `extendConfig` to *both* configs. Once `--experimental-modules` is on, that injects the jQuery `ProvidePlugin` and the custom SCSS/admin entries into the ESM module build, which breaks `view.js` output. The new `if (config.experiments?.outputModule) return config;` guard passes the module config through untouched.

Confirmed empirically that with the boilerplate's zero blocks, `build --experimental-modules` still exits 0 — the flag is harmless when there are no interactive blocks.

## Changes

- `package.json` — `--experimental-modules` on `start` and `build`
- `webpack.config.js` — `outputModule` guard in `extendConfig`
- `docs/bundeling.mdx`, `AGENTS.md`, `.agents/skills/wp-plugin-bp/references/bundling.md` — doc updates per the boilerplate maintenance rule

## Test plan

- [x] `npm run build` (with flag) exits 0 with zero blocks
- [x] `webpack.config.js` parses and still returns an array config