### PR TITLE
CI: cache wp-env Docker images to speed up application tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,8 +70,38 @@ jobs:
           sed -i -E 's/([[:blank:]]*\*[[:blank:]]*Version:[[:blank:]]*).*/\1${{ env.RELEASE_VERSION }}/' demo-plugin.php
           sed -i -E 's/Stable tag: .*/Stable tag: ${{ env.RELEASE_VERSION }}/' README.txt
 
+      # Cache the wp-env Docker images between runs. wp-env has no native cache
+      # hook, so we cache at the Docker daemon level via save/load. The post-step
+      # of actions/cache only uploads on a miss, so the "Save" step below
+      # populates the directory whenever the cache was not hit.
+      - name: Cache wp-env Docker images
+        id: wp-env-docker-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.wp-env-docker-cache
+          key: wp-env-docker-${{ runner.os }}-${{ hashFiles('.wp-env.json', 'package-lock.json') }}
+
+      - name: Load cached wp-env Docker images
+        if: steps.wp-env-docker-cache.outputs.cache-hit == 'true'
+        run: |
+          for img in ~/.wp-env-docker-cache/*.tar; do
+            [ -e "$img" ] || continue
+            docker load -i "$img"
+          done
+
       - name: Start wp-env
         run: npm run env:start
+
+      - name: Save wp-env Docker images for next run
+        if: steps.wp-env-docker-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.wp-env-docker-cache
+          docker images --format '{{.Repository}}:{{.Tag}}' \
+            | grep -iE 'wordpress|mariadb|mysql|wp-env|cli' \
+            | while read -r image; do
+                safe=$(echo "$image" | tr '/:' '__')
+                docker save "$image" -o ~/.wp-env-docker-cache/"$safe".tar
+              done
 
       - name: Compile translations in wp-env from po files
         run: npm run env:cli composer run i18n:compile

--- a/.github/workflows/test-analyse.yml
+++ b/.github/workflows/test-analyse.yml
@@ -107,8 +107,38 @@ jobs:
           $COMPOSER_AUTH
           EOF
 
+      # Cache the wp-env Docker images between runs. wp-env has no native cache
+      # hook, so we cache at the Docker daemon level via save/load. The post-step
+      # of actions/cache only uploads on a miss, so the "Save" step below
+      # populates the directory whenever the cache was not hit.
+      - name: Cache wp-env Docker images
+        id: wp-env-docker-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.wp-env-docker-cache
+          key: wp-env-docker-${{ runner.os }}-${{ hashFiles('.wp-env.json', 'package-lock.json') }}
+
+      - name: Load cached wp-env Docker images
+        if: steps.wp-env-docker-cache.outputs.cache-hit == 'true'
+        run: |
+          for img in ~/.wp-env-docker-cache/*.tar; do
+            [ -e "$img" ] || continue
+            docker load -i "$img"
+          done
+
       - name: Start wp-env
         run: npm run env:start
+
+      - name: Save wp-env Docker images for next run
+        if: steps.wp-env-docker-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.wp-env-docker-cache
+          docker images --format '{{.Repository}}:{{.Tag}}' \
+            | grep -iE 'wordpress|mariadb|mysql|wp-env|cli' \
+            | while read -r image; do
+                safe=$(echo "$image" | tr '/:' '__')
+                docker save "$image" -o ~/.wp-env-docker-cache/"$safe".tar
+              done
 
       - name: Run application tests
         run: npm run test:php


### PR DESCRIPTION
Closes #196.

## What

Caches the wp-env Docker images (WordPress / MySQL / CLI) between CI runs so the `Start wp-env` step doesn't re-pull them on every push. wp-env exposes no native cache hook, so the cache is done at the Docker daemon level via a `docker save` / `docker load` round-trip.

## How

- **Restore** images with `actions/cache@v5`, keyed on `.wp-env.json` + `package-lock.json` (so an env change or a wp-env version bump invalidates it).
- **Load** the cached tarballs into the daemon on a cache hit — `wp-env start` then skips the pulls.
- **Save** the relevant images into the cache directory only on a miss; `actions/cache`'s post-step uploads it automatically (it skips upload when the key already hit).

## Scope — applies to both wp-env jobs

The issue only called out the test job, but `deploy.yml` also runs `npm run env:start`, so the same cache was added there:

- `.github/workflows/test-analyse.yml` → `test-application` job
- `.github/workflows/deploy.yml` → `deploy` job

## Notes

- Beyond the speedup, this sidesteps Docker Hub pull rate-limit flakiness, which is often the bigger win in CI.
- The image-selection `grep` (`wordpress|mariadb|mysql|wp-env|cli`) is intentionally broad; once a CI run logs the exact image list we can tighten it.
- Both workflow files validated as parseable YAML.

## Verification

Real timing can only be observed on GitHub's runners. To confirm once merged/run:
- [ ] On a warm cache, `Load cached wp-env Docker images` runs and `Start wp-env` performs no pulls (check logs).
- [ ] Cache invalidates when `.wp-env.json` or wp-env version changes.
- [ ] `Start wp-env` step duration drops vs. baseline.
